### PR TITLE
🏠 Add initial blog post about Jupyter Book project

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -20,6 +20,21 @@ project:
       affiliations:
         - Jupyter Book
         - 2i2c
+    - name: Rowan Cockett
+      orcid: 0000-0002-7859-8394
+      affiliations:
+        - Jupyter Book
+        - Curvenote
+    - name: Franklin Koch
+      orcid: 0000-0002-6393-7058
+      affiliations:
+        - Jupyter Book
+        - Curvenote
+    - name: Steve Purves
+      orcid: 0000-0002-0760-5497
+      affiliations:
+        - Jupyter Book
+        - Curvenote
   references:
     jpy-gov: https://jupyter.org/governance/
   github: https://github.com/jupyter-book/blog

--- a/myst.yml
+++ b/myst.yml
@@ -15,6 +15,11 @@ project:
       affiliations:
         - Jupyter Book
         - 2i2c
+    - name: Chris Holdgraf
+      orcid: 0000-0002-2391-0678
+      affiliations:
+        - Jupyter Book
+        - 2i2c
   references:
     jpy-gov: https://jupyter.org/governance/
   github: https://github.com/jupyter-book/blog

--- a/myst.yml
+++ b/myst.yml
@@ -3,12 +3,14 @@ version: 1
 extends:
   - https://raw.githubusercontent.com/jupyter-book/meta/refs/heads/main/myst.yml
 project:
-  title: 'Jupyter Book: Blog'
+  title: "Jupyter Book: Blog"
   description: Updates from the Jupyter Book subproject.
   keywords:
     - Jupyter
     - JupyterBook
     - MyST Markdown
+  references:
+    jpy-gov: https://jupyter.org/governance/
   github: https://github.com/jupyter-book/blog
   # To autogenerate a Table of Contents, run "myst init --write-toc"
   license: CC0-1.0

--- a/myst.yml
+++ b/myst.yml
@@ -9,6 +9,12 @@ project:
     - Jupyter
     - JupyterBook
     - MyST Markdown
+  authors:
+    - name: Angus Hollands
+      orcid: 0000-0003-0788-3814
+      affiliations:
+        - Jupyter Book
+        - 2i2c
   references:
     jpy-gov: https://jupyter.org/governance/
   github: https://github.com/jupyter-book/blog

--- a/posts/2024-11-11-jupyter-book-org.md
+++ b/posts/2024-11-11-jupyter-book-org.md
@@ -2,11 +2,6 @@
 title: Jupyter Book Becomes a Jupyter Subproject
 subtitle: Jupyter Book joins the ranks of other Jupyter Subprojects such as JupyterLab and JupyterHub.
 date: 2024-11-11
-authors:
-  - name: Angus Hollands
-    orcid: 0000-0003-0788-3814
-    affiliations:
-      - Jupyter Book
 license: CC-BY-4.0
 ---
 

--- a/posts/2024-11-11-jupyter-book-org.md
+++ b/posts/2024-11-11-jupyter-book-org.md
@@ -10,15 +10,20 @@ authors:
 license: CC-BY-4.0
 ---
 
-
 Over the last ten months, the Jupyter Book team have been hard at work building the next major version of Jupyter Book (see [the blog post][plan]). During this time, a strong distinction between the tools developed for the legacy Sphinx application and its new [MyST Engine][mystmd]-powered sibling has arisen, leading to the submission of a [Jupyter Enhancement Proposal to incorporate Jupyter Book][book-jep] as a Jupyter Subproject.
 
-Under the Jupyter organisation, the Jupyter Book team hopes to have found a
-> longer-lasting and organizationally-neutral home for the vision, strategy, tools, and standards of this modern version of the Jupyter Book toolchain.
-> -- Jupyter Enhancement Proposal #122
+Under the Jupyter organisation, the Jupyter Book team hopes to have found
 
-Keep an eye on this blog for news about the upcoming Jupyter Book 2 alpha release.
+> a longer-lasting and organizationally-neutral home for the vision, strategy, tools, and standards of this modern version of the Jupyter Book toolchain.
+>
+> -- [Jupyter Enhancement Proposal #122](https://github.com/jupyter/enhancement-proposals/pull/123)
 
+To facilitate the creation of a Jupyter Subproject, a [new `jupyter-book` GitHub Organisation][jbp] has been created. This new organisation is distinct from the [Executable Books organisation][ebp] that served as the home for previous releases of Jupyter Book; It will act as the hub for all future development and discussion surrounding Jupyter Book development.
+
+For more news about Jupyter Book, such as the upcoming Jupyter Book 2 alpha release, please keep an eye on this blog!
+
+[jbp]: https://github.com/jupyter-book
+[ebp]: https://github.com/executablebooks
 [plan]: https://executablebooks.org/en/latest/blog/2024-05-20-jupyter-book-myst/
 [book-jep]: https://github.com/jupyter/enhancement-proposals/pull/123
 [mystmd]: https://mystmd.org

--- a/posts/2024-11-11-jupyter-book-org.md
+++ b/posts/2024-11-11-jupyter-book-org.md
@@ -1,0 +1,24 @@
+---
+title: Jupyter Book Becomes a Jupyter Subproject
+subtitle: Jupyter Book joins the ranks of other Jupyter Subprojects such as JupyterLab and JupyterHub.
+date: 2024-11-11
+authors:
+  - name: Angus Hollands
+    orcid: 0000-0003-0788-3814
+    affiliations:
+      - Jupyter Book
+license: CC-BY-4.0
+---
+
+
+Over the last ten months, the Jupyter Book team have been hard at work building the next major version of Jupyter Book (see [the blog post][plan]). During this time, a strong distinction between the tools developed for the legacy Sphinx application and its new [MyST Engine][mystmd]-powered sibling has arisen, leading to the submission of a [Jupyter Enhancement Proposal to incorporate Jupyter Book][book-jep] as a Jupyter Subproject.
+
+Under the Jupyter organisation, the Jupyter Book team hopes to have found a
+> longer-lasting and organizationally-neutral home for the vision, strategy, tools, and standards of this modern version of the Jupyter Book toolchain.
+> -- Jupyter Enhancement Proposal #122
+
+Keep an eye on this blog for news about the upcoming Jupyter Book 2 alpha release.
+
+[plan]: https://executablebooks.org/en/latest/blog/2024-05-20-jupyter-book-myst/
+[book-jep]: https://github.com/jupyter/enhancement-proposals/pull/123
+[mystmd]: https://mystmd.org


### PR DESCRIPTION
This PR adds a simple blog post that details the launch of JB as a Jupyter Subproject.