### PR TITLE
Clean up landing page and improve dev docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # MyST build outputs
 _build
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# blog
-Blog for the Jupyter Book subproject
+# The Jupyter Book blog
+
+A blog for the Jupyter Book subproject.
+
+## Local development
+
+This blog is a small [MyST site](https://mystmd.org) along with a [javascript plugin for blogging](plugins/blog.mjs).
+
+To run it locally, take these steps:
+
+1. **Install NPM and MyST** by [following the MyST installation instructions](https://mystmd.org/guide/installing).
+2. **Install the plugin requirements** with NPM:
+
+   ```shell
+   $ npm install
+   ```
+3. **Build the site**:
+
+   ```shell
+   $ myst start
+   ```

--- a/index.md
+++ b/index.md
@@ -1,9 +1,24 @@
 ---
 site:
   hide_title_block: true
+  hide_outline: true
 ---
 
 # Blog
+
+% This is a hack because hiding the title block removes the margin and title
+% Whereas we just want to remove the button links etc.
+<div style="margin-top: 1em;">
+
+## Welcome to the Jupyter Book blog! 👋
+
+</div>
+
+This is a place for [the Jupyter Book team](https://compass.jupyterbook.org) to share updates from the community and the project.[^ebp]
+
+[^ebp]: See the [Executable Books blog](https://executablebooks.org/en/latest/blog/) for blog posts from when Jupyter Book was a part of the Executable Books project. See this [post about moving to Jupyter](posts/2024-11-11-jupyter-book-org.md) for context on the move from Executable Books to Jupyter.
+
+## Recent blog posts
 
 :::{blog-posts}
 :::

--- a/plugins/blog.mjs
+++ b/plugins/blog.mjs
@@ -28,17 +28,8 @@ const blogPostsDirective = {
         ? [
             {
               type: "footer",
-              children: [
-                {
-                  type: "paragraph",
-                  children: [
-                    {
-                      type: "text",
-                      value: `Date: ${frontmatter.date}`,
-                    },
-                  ],
-                },
-              ],
+              // Pull out the first child of `root` node.
+              children: [ctx.parseMyst(`**Date**: ${frontmatter.date}`)["children"][0]],
             },
           ]
         : [];


### PR DESCRIPTION
This does a couple of things:

1. Cleans up the landing page so that it has a bit more context.
2. Adds a brief readme so others know how to run this locally.
3. Small update to the plugin logic to make the **Date** in bold.