### PR TITLE
🛠️ Validate `frontmatter` before using it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "devDependencies": {
         "glob": "^11.0.0",
-        "myst-transforms": "^1.3.27",
+        "myst-frontmatter": "^1.7.10",
+        "myst-transforms": "^1.3.33",
         "mystmd": "^1.3.17"
       }
     },
@@ -310,9 +311,9 @@
       }
     },
     "node_modules/doi-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/doi-utils/-/doi-utils-2.0.3.tgz",
-      "integrity": "sha512-vXWjB8Wz195m0PSw9jCwkCVBtPO+yIY/iPUQ1qTLD3GZ7alXreaoLKA3D4MAewPOBt+D8BU1LJiOF7WKpy9ifQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/doi-utils/-/doi-utils-2.0.5.tgz",
+      "integrity": "sha512-BAaEF9L9KqJmQfk1frtgAySPnwOdaY2UzZ85XvFAMLdGeqrH/GiwIziQU2y3WgrCuQ0ng74bq5uYBo8Qma/WqA==",
       "dev": true,
       "license": "MIT"
     },
@@ -329,6 +330,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
@@ -1120,6 +1134,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
@@ -1128,6 +1152,23 @@
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
+      "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
       }
     },
     "node_modules/mdast": {
@@ -1403,14 +1444,14 @@
       }
     },
     "node_modules/myst-common": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/myst-common/-/myst-common-1.7.4.tgz",
-      "integrity": "sha512-zFJcbi40dCTE9f5q7xuG/n50mF8IOhEl/nQQ6wLUJTFjhWkmTbtUzL1/qf+l38vk72vF6ytgw4VJJW3ur44mKw==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/myst-common/-/myst-common-1.7.10.tgz",
+      "integrity": "sha512-DEeFwDvtF7HiUkfvW44YuVMhgSHSuQ1bG40/u1lotyv1KTMP0P7kc63vSZcaEntRnVzTqtdWaEuw8I16QT0RCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdast": "^3.0.0",
-        "myst-frontmatter": "^1.7.4",
+        "myst-frontmatter": "^1.7.10",
         "myst-spec": "^0.0.5",
         "nanoid": "^4.0.0",
         "unified": "^10.1.2",
@@ -1422,14 +1463,14 @@
       }
     },
     "node_modules/myst-frontmatter": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/myst-frontmatter/-/myst-frontmatter-1.7.4.tgz",
-      "integrity": "sha512-1CJ9/sKcPszk9llBNejnPhyLndhiBT19YSEHnq9yuJbKDyk3qnS2HaPkUDdkfTW+7b0WiuBN8KNP1VroYcKE1g==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/myst-frontmatter/-/myst-frontmatter-1.7.10.tgz",
+      "integrity": "sha512-TT9Fw3FSEK7eZ16WkFLS6MOFEpBbDIDuV8AxRoAyAQfC9D7vC2qmkOVWSd0+cug2PVpNdoWCFkBJOjeEKM7Dmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "credit-roles": "^2.1.0",
-        "doi-utils": "^2.0.0",
+        "doi-utils": "^2.0.5",
         "myst-toc": "^0.1.2",
         "orcid": "^1.0.0",
         "simple-validators": "^1.1.0",
@@ -1444,9 +1485,9 @@
       "license": "MIT"
     },
     "node_modules/myst-spec-ext": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/myst-spec-ext/-/myst-spec-ext-1.7.4.tgz",
-      "integrity": "sha512-A584gNioW3NTC4itkoxpt7Fqvvzg9zF++lPu5lVkYorq/XoBK8XdWjgNtxPHIeK352XGEDYh4YmaM9ScQXx3ow==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/myst-spec-ext/-/myst-spec-ext-1.7.10.tgz",
+      "integrity": "sha512-vQFaTGRT7KRCl0TQ9RuFCArAWFd5AQNMFZP+xWmm/NHH08q8NtNP2U1FTvc1v597XO1f7JJLBezToYBv39gxwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1454,9 +1495,9 @@
       }
     },
     "node_modules/myst-to-html": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/myst-to-html/-/myst-to-html-1.5.8.tgz",
-      "integrity": "sha512-+zc8fN0J+MwRxUNThxBtM98KKfmoIQ4aHRZRcrzMyf/u54HWR/RpxLe8LVTeF4pGS7+wOmzQ6XGwLD6MrHWnuA==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/myst-to-html/-/myst-to-html-1.5.12.tgz",
+      "integrity": "sha512-meswh0aGHMZ6HOVehUsbDUFpifqPiM29Qve11x/oVVgH8O4bxdo/Y6phk1iepvOg/ew05cQh2IsczLuCy2FMZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1467,7 +1508,7 @@
         "mdast": "^3.0.0",
         "mdast-util-find-and-replace": "^2.1.0",
         "mdast-util-to-hast": "^12.3.0",
-        "myst-common": "^1.7.4",
+        "myst-common": "^1.7.9",
         "rehype-format": "^4.0.1",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
@@ -1478,46 +1519,6 @@
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.3",
         "unist-util-visit": "^4.1.0"
-      }
-    },
-    "node_modules/myst-to-html/node_modules/entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/myst-to-html/node_modules/linkify-it": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
-      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^1.0.1"
-      }
-    },
-    "node_modules/myst-to-html/node_modules/markdown-it": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
-      "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "~3.0.1",
-        "linkify-it": "^4.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.js"
       }
     },
     "node_modules/myst-toc": {
@@ -1531,24 +1532,24 @@
       }
     },
     "node_modules/myst-transforms": {
-      "version": "1.3.27",
-      "resolved": "https://registry.npmjs.org/myst-transforms/-/myst-transforms-1.3.27.tgz",
-      "integrity": "sha512-R4ggES6PGgBrlPGFwmyTmR9d5dOurzXAg2BUvWFKUg6xTAKLsJkVswd4z6faANoydZbOFg9gHuzO72vcj4bz7Q==",
+      "version": "1.3.33",
+      "resolved": "https://registry.npmjs.org/myst-transforms/-/myst-transforms-1.3.33.tgz",
+      "integrity": "sha512-hWamCqkYLxlOpkLOb0U26gExdxEz8fSHGhi+25xRglEVr6BnBFRvsx6GKu6tfr2vOwHjca0Ed+tlm+MQV+2Vkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "doi-utils": "^2.0.0",
+        "doi-utils": "^2.0.5",
         "hast-util-from-html": "^2.0.1",
         "hast-util-to-mdast": "^8.3.1",
         "intersphinx": "^1.0.2",
         "js-yaml": "^4.1.0",
         "katex": "^0.15.2",
         "mdast-util-find-and-replace": "^2.1.0",
-        "myst-common": "^1.7.4",
-        "myst-frontmatter": "^1.7.4",
+        "myst-common": "^1.7.10",
+        "myst-frontmatter": "^1.7.10",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.7.4",
-        "myst-to-html": "1.5.8",
+        "myst-spec-ext": "^1.7.10",
+        "myst-to-html": "1.5.12",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
         "unified": "^10.0.0",
@@ -2034,9 +2035,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
-      "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
       "dev": true,
       "license": "CC0-1.0"
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "ISC",
   "devDependencies": {
     "glob": "^11.0.0",
-    "myst-transforms": "^1.3.27",
+    "myst-transforms": "^1.3.33",
+    "myst-frontmatter": "^1.7.10",
     "mystmd": "^1.3.17"
   }
 }


### PR DESCRIPTION
The plugin that generates the list of blog posts pulls the frontmatter of the page, but presently does not validate it. This means that if you e.g. set a raw YAML date, we display that as-is, rather than canonicalising it.

![image](https://github.com/user-attachments/assets/8ab2aafa-6447-4bcb-8e10-f69ea88471c9)

vs

![image](https://github.com/user-attachments/assets/278e57d2-cf28-4e7c-9266-b5dbd139c5bd)

