### PR TITLE
Add a script that auto-adds release notes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,14 @@ jobs:
           node-version: 20.x
       - name: Install MyST Markdown
         run: npm install -g mystmd
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Generate Release Notes from GitHub Releases
+        run: python src/generate_release_notes.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build HTML Assets
         run: myst build --html
       - name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # MyST build outputs
 _build
 node_modules
+posts/releases/*.md
+!posts/releases/README.md

--- a/README.md
+++ b/README.md
@@ -19,3 +19,49 @@ To run it locally, take these steps:
    ```shell
    $ myst start
    ```
+
+## Release Posts
+
+The `posts/releases/` folder contains automatically generated release posts for all repositories in the Jupyter Book organization.
+
+### To add release notes to the blog
+
+1. Make the release on GitHub
+2. Re-build the blog
+
+The blog action will catch the latest release and include it in the list, sorted by dates.
+
+### How it works
+
+The release posts are generated automatically using the `src/generate_release_notes.py` script, which:
+
+1. **Fetches all repositories** from the `jupyter-book` GitHub organization
+2. **Retrieves all releases** from each repository using the GitHub API
+3. **Sorts releases by date** (newest first)
+4. **Generates numbered markdown files** with proper frontmatter
+5. **Formats @mentions** with backticks for better readability
+6. **Adds formatted dates** to titles (e.g., "July 6th, 2025")
+
+### File Naming Convention
+
+Files are named with a numbered prefix to ensure proper ordering until we make it possible to list blog posts sorted by date:
+- `001-{repo-name}-{release-title}.md` (newest release)
+- `002-{repo-name}-{release-title}.md`
+- ...
+- `224-{repo-name}-{release-title}.md` (oldest release)
+
+### Generating Release Posts
+
+To generate the release posts locally:
+
+```shell
+$ python src/generate_release_notes.py
+```
+
+**Requirements:**
+- GitHub CLI (`gh`) must be installed and authenticated
+- Python 3 for processing JSON data
+
+### Automation
+
+The release posts are automatically generated during the CI/CD build process (see `.github/workflows/deploy.yml`). This ensures that new releases are always included in the blog without manual intervention.

--- a/myst.yml
+++ b/myst.yml
@@ -48,8 +48,13 @@ project:
   github: https://github.com/jupyter-book/blog
   # To autogenerate a Table of Contents, run "myst init --write-toc"
   license: CC0-1.0
+  exclude:
+    - posts/releases/README.md
   toc:
     - file: index.md
+    - title: Releases
+      children:
+        - pattern: posts/releases/*.md
     - title: "2025"
       children:
         - pattern: posts/2025-*.md

--- a/src/generate_release_notes.py
+++ b/src/generate_release_notes.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Script to generate release notes from GitHub releases in the jupyter-book org.
+"""
+
+import json
+import re
+import subprocess
+import sys
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+
+def format_date(date_str):
+    """Convert ISO date string to readable format like 'June 17th, 2025'"""
+    date_obj = datetime.strptime(date_str, "%Y-%m-%d")
+
+    # Get month name
+    month = date_obj.strftime("%B")
+
+    # Get day with ordinal suffix
+    day = date_obj.day
+    if 4 <= day <= 20 or 24 <= day <= 30:
+        suffix = "th"
+    else:
+        suffix = ["st", "nd", "rd"][day % 10 - 1]
+
+    # Get year
+    year = date_obj.year
+
+    return f"{month} {day}{suffix}, {year}"
+
+
+def main():
+    # Check if gh command exists
+    try:
+        subprocess.run(["gh", "--version"], capture_output=True, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("Error: GitHub CLI (gh) is not installed or not available in PATH")
+        print("Please install it from: https://cli.github.com/")
+        sys.exit(1)
+
+    # Configuration
+    org = "jupyter-book"
+    releases_dir = Path("posts/releases")
+    temp_dir = Path("_build/release_notes")
+
+    # Clean and ensure directories exist
+    if releases_dir.exists():
+        shutil.rmtree(releases_dir)
+    releases_dir.mkdir(parents=True, exist_ok=True)
+    temp_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Fetching all repositories from {org} organization...")
+
+    # Fetch all repositories
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"orgs/{org}/repos", "--paginate"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        repos = json.loads(result.stdout)
+    except subprocess.CalledProcessError as e:
+        print(f"Error fetching repositories: {e}")
+        sys.exit(1)
+
+    print("Fetching releases from all repositories...")
+
+    all_releases = []
+
+    for repo in repos:
+        repo_name = repo["name"]
+        print(f"Fetching releases from {repo_name}...")
+
+        try:
+            result = subprocess.run(
+                ["gh", "api", f"repos/{org}/{repo_name}/releases", "--paginate"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            releases = json.loads(result.stdout)
+
+            for release in releases:
+                release["repo_name"] = repo_name
+                all_releases.append(release)
+
+        except subprocess.CalledProcessError:
+            print(f"No releases found for {repo_name}")
+        except json.JSONDecodeError:
+            print(f"Error parsing releases for {repo_name}")
+
+    # Sort releases by publication date so the largest numbers are the newest.
+    # this forces latest releases to the top until we have a proper sorting system.
+    all_releases.sort(key=lambda x: x["published_at"], reverse=True)
+
+    total = len(all_releases)
+    print(f"Found {total} total releases")
+
+    for ii, release in enumerate(all_releases):
+        number = ii + 1
+        title = release["name"] or release["tag_name"]
+        repo_name = release["repo_name"]
+
+        # Add repository name to title if it's not already present
+        # Normalize both strings by replacing hyphens, underscores, and spaces
+        normalized_repo = (
+            repo_name.lower().replace("-", "").replace("_", "").replace(" ", "")
+        )
+        normalized_title = (
+            title.lower().replace("-", "").replace("_", "").replace(" ", "")
+        )
+
+        if normalized_repo not in normalized_title:
+            title = f"{repo_name} {title}"
+
+        date = release["published_at"][:10]
+        formatted_date = format_date(date)
+        title = f"{title} - {formatted_date}"
+        body = release["body"] or ""
+
+        # Wrap @mentions in backticks (only if preceded by space, (, comma, or [, and not already wrapped)
+        body = re.sub(r"(?<=[\s(,\[])@(\w+)(?!`)", r"`@\1`", body)
+
+        # Create filename
+        safe_title = re.sub(r"[^a-zA-Z0-9-]", "-", title.lower())
+        filename = releases_dir / f"{number:03d}-{repo_name}-{safe_title}.md"
+
+        # Write the markdown file
+        with open(filename, "w") as f:
+            f.write("---\n")
+            f.write(f"title: {title}\n")
+            f.write(f"date: {date}\n")
+            f.write("author: The Jupyter Book Team\n")
+            f.write("tags:\n")
+            f.write("  - release\n")
+            f.write("---\n\n")
+            f.write(body)
+            f.write("\n")
+
+        print(f"Generated: {filename}")
+
+    print("Release posts generated successfully!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds a Python script that scrapes GitHub for the list of all releases from the `jupyter-book` organization, and lists them in reverse chronological order in a `Releases` folder. This way we don't have to do any copy/pasting of releases into the blog. A few thoughts:

- It's a bit hacky because we don't have a way to do `reverse: true` for our pattern matching, so I have to ensure the latest blog posts start with `1` and go up from there.
- When we have a proper listing plugin we can probably rely on that rather than on our sidebar.
- We're not including this in our `blogposts` directive because it's in a dedicated folder and in a different sorting order