### PR TITLE
fix: update link to cafe

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -45,6 +45,7 @@ project:
   references:
     jpy-gov: https://jupyter.org/governance/
     guide: https://mystmd.org/guide
+    compass: https://compass.jupyterbook.org
   github: https://github.com/jupyter-book/blog
   # To autogenerate a Table of Contents, run "myst init --write-toc"
   license: CC0-1.0

--- a/posts/2025-04-09-new-community-meeting.md
+++ b/posts/2025-04-09-new-community-meeting.md
@@ -33,16 +33,11 @@ Each month, at alternating days and slightly different formats.
 - **Month A**: Tuesdays, shared with the [JupyterHub Collaboration Cafe][hub-cafe].
 - **Monthy B**: Wednesdays, with the Jupyter Book community.
 
-See @schedule for the Jupyter calendar, which includes the events described here as well as information for connecting.
+See below for links to the various community contact points, which includes the events described here as well as information for connecting.
 
-::::{figure}
-:label: schedule
-:::{iframe} https://calendar.google.com/calendar/embed?src=m3hek69dag7381umt8kcjd75u4%40group.calendar.google.com&ctz=America%2FChicago
-:::
+:::{embed} xref:compass/contribute#where-to-talk
 
-The meeting schedule for JupyterHub Collaboration Cafe
 ::::
 
 [ttw-cafe]: https://book.the-turing-way.org/community-handbook/community-calls/community-calls-collabcafe
 [hub-cafe]: https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings/collab-cafe/index.html
-[jupyter-cal]: https://jupyter.org/community#live-events


### PR DESCRIPTION
I noticed that we still use the old link. Updating the blog to point to the always-current content.

Before:
<img width="699" height="419" alt="image" src="https://github.com/user-attachments/assets/e831ea7e-0665-414f-81ee-63093905172e" />


After:
<img width="699" height="367" alt="image" src="https://github.com/user-attachments/assets/598d5c2e-48ab-4e55-92e7-7b861af744cb" />
