### PR TITLE
Add jupytercon cfp text

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -12,6 +12,9 @@ project:
     - JupyterBook
     - MyST Markdown
   contributors:
+    - id: jb-team
+      name: The Jupyter Book Team
+      url: https://compass.jupyterbook.org/team
     - id: agoose77
       name: Angus Hollands
       orcid: 0000-0003-0788-3814

--- a/posts/2025-07-23-jupytercon-cfp.md
+++ b/posts/2025-07-23-jupytercon-cfp.md
@@ -1,0 +1,21 @@
+---
+title: Our submission for JupyterCon 2025
+date: "2025-07-23"
+license: CC-BY-4.0
+authors:
+  - jb-team
+---
+
+We recently submitted an abstract for JupyterCon 2025! We're sharing the text below in case others are interested to learn about what we'd like to talk about.
+
+## Introducing Jupyter Book 2: Next-generation tools and standards for creating and sharing computational narratives.
+
+Jupyter Book is a core tool for sharing computational science, powering more than 14,000 open, online textbooks, knowledge bases, lectures, courses and community sites. It allows researchers and educators to create books and knowledge bases that are reusable, reproducible, and interactive. 
+
+Over the past two years, we have rebuilt Jupyter Book from the ground up, focused on allowing authors to produce machine readable, semantically structured content that can be flexibly deployed and that supports reuse and cross referencing in unprecedented ways. We achieved this by adopting, stewarding, and developing the MyST Markdown Document Engine ([https://mystmd.org](https://mystmd.org/)), a more flexible and extensible engine that integrates with Jupyter for interactive computation. Jupyter Book 2 represents a major leap forward in how we share and distribute computational content on the web.
+
+In this talk, we will cover the key differentiating ideas driving Jupyter Book 2 and MyST, and showcase real-world examples like The Turing Way, QuantEcon, Project Pythia, and the SciPy Proceedings. We'll demonstrate major new functionality with live demos, and give the audience practical tips for getting started with the new Jupyter Book 2 stack.
+
+### Benefits to the Ecosystem
+
+Jupyter Book is a subproject of Project Jupyter that focuses primarily on authoring and sharing computational narratives. It builds and interconnects with other tools in the Jupyter ecosystem to provide a seamless experience when leveraging Jupyter tools to communicate knowledge with data and computation. MyST Markdown is an extended markdown syntax used across many parts of the Jupyter ecosystem, and the MyST Document Engine is designed to be flexible enough to extend Jupyter technology to more directly support key workflows built on MyST like scholarly publishing. This talk covers a major advance in both projects, which has benefits and potential integrations that may benefit workflows across the entire Jupyter stack.


### PR DESCRIPTION
This adds the text from our JupyterCon CfP submission for 2025. I don't know of any other submissions from the "whole Jupyter Book team", but if there are any, or if anybody made a personal submission they want to highlight on the Jupyter Book blog, then please suggest adding it and we can generalize this post to have the text of many submissions!