### PR TITLE
Removing double linking

### DIFF
--- a/posts/2025-11-13-numpy-tutorials-jb2.md
+++ b/posts/2025-11-13-numpy-tutorials-jb2.md
@@ -13,7 +13,7 @@ The NumPy tutorials [landing page](https://https://numpy.org/numpy-tutorials/) n
 
 This work came out of the [Scientific Python Developer Summit in Copenhagen](https://scientific-python.org/summits/developer/2025-nov/) in November 2025. The summit created space for NumPy contributors to share experiences with the broader ecosystem and tackle the migration as a focused, right-sized project.
 
-The NumPy tutorials maintainers agreed to migrate to JB2 because the material focuses on narrative and notebook content and [doesn't need API documentation](https://github.com/jupyter-book/mystmd/issues/1259). Seeing NumPy make this transition is a good sign that JB2 is ready for production use in major open source projects - and that JB2 can cover an even bigger chunk of use-cases once we add [API docs support](https://github.com/jupyter-book/mystmd/issues/1259).
+The NumPy tutorials maintainers agreed to migrate to JB2 because the material focuses on narrative and notebook content and [doesn't need API documentation](https://github.com/jupyter-book/mystmd/issues/1259). Seeing NumPy make this transition is a good sign that JB2 is ready for production use in major open source projects - and that JB2 can cover an even bigger chunk of use-cases once we add API docs support.
 
 ## Acknowledgments
 


### PR DESCRIPTION
I was just checking the deployed entry and linking to the same issue twice in a sentence looked weird. I also wanted to fix the link to the PR instead of the issue; but in fact realised that's a bug (#42) and not a mistake in the blogpost itself